### PR TITLE
fix record type declaration for Erlang/OTP 18.0

### DIFF
--- a/src/elli_ws_request_adapter.erl
+++ b/src/elli_ws_request_adapter.erl
@@ -62,7 +62,7 @@
 	websocket_compress=false :: boolean()
 	}).
 
--type req() :: record(req_adapter).
+-type req() :: #req_adapter{}.
 
 
 %%


### PR DESCRIPTION
just a micro tiny fix for Erlang/OTP 18.0, not sure if it is back compatible for <= 17.

_Off Topic:_
I am using elli websocket for my [Elixir Plug Adapter](https://github.com/zampino/pastelli)
for Elli and your library builds
with no issue (I didn't check SSL) against elli's latest master.

Shall I then remove your note
> At the moment elli_websocket is dependant on a handover and ssl feature and needs a specific elli branch.

from the README, maybe in this very pull request? 