### PR TITLE
elli_ws_protocol#state.env now type list().

### DIFF
--- a/src/elli_ws_protocol.erl
+++ b/src/elli_ws_protocol.erl
@@ -61,7 +61,7 @@
 -type rsv() :: << _:3 >>.
 
 -record(state, {
-	env :: [], %% cowboy_middleware:env(),
+	env :: list(), %% cowboy_middleware:env(),
 	socket = undefined :: undefined | elli_tcp:socket(),
 	handler :: module(),
 	key = undefined :: undefined | binary(),


### PR DESCRIPTION
elli_ws_protocol#state.env was typed as an empty list, which resulted in dialyzer generating the following error when users tried passing in valid options to elli_websocket:upgrade/2:

`The call elli_websocket:upgrade(Req::any(), WsArgs::[{'handler','***'} | {'handler_opts',[]} | {'resp_compress','false'},...]) will never return since it differs in the 2nd argument from the success typing arguments: (#req{method::'DELETE' | 'GET' | 'HEAD' | 'OPTIONS' | 'POST' | 'PUT' | 'TRACE' | 'undefined' | binary(),path::'undefined' | [binary()],args::'undefined' | [{binary(),_}],raw_path::'undefined' | binary(),version::'undefined' | {0 | 1,0 | 1 | 9},headers::'undefined' | [{binary(),binary() | [any()]}],body::'undefined' | binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []),pid::'undefined' | pid(),socket::'undefined' | {'plain',port()} | {'ssl',_},callback::'undefined' | {atom() | tuple(),_}}, [])`

To correct this, the type of elli_ws_protocol#state.env must be `list()`.
